### PR TITLE
PAASTA-16454: Upgrade kind default base image for k8s itests to 1.17.4

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.16.2@sha256:146ffa1427f3995abdfb710981da4e67637e6f50cffdeea29b207f098300a1f4"
+const Image = "kindest/node:v1.17.4@sha256:d8791dd1d5a98c399ce3fb7c69836da0e445cb7bdd5efa0735c945788bd81a10"


### PR DESCRIPTION
### Context
Currently, we are running k8s v1.16.2 for itests. Devboxes run k8s via kind which creates running local Kubernetes clusters using Docker container “nodes”. We want to bump the version k8s to 1.17.4 in order to match our dev/stage/prod clusters at Yelp. 

Note that we use a forked version of `kubernetes-sigs/kind` (release v0.5.1) which defaults to k8s node image to v1.15.3. This version of kind does not contain v1.17.4 as a default. See https://github.com/kubernetes-sigs/kind/releases/tag/v0.5.0.

Therefore, we need to build our own image and specify its configs https://kind.sigs.k8s.io/docs/user/configuration/#nodes.

### What we're doing
The following code bumps this version and uses the official k8s v1.17.4 sha256 from https://github.com/kubernetes/kubernetes/releases/tag/v1.17.4
 